### PR TITLE
chore(deps): bump rust flate2 from 1.1.9 to 1.1.10

### DIFF
--- a/native/xlsx_writer/Cargo.lock
+++ b/native/xlsx_writer/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,11 +31,10 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
- "miniz_oxide",
  "zlib-rs",
 ]
 
@@ -103,16 +96,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "proc-macro2"


### PR DESCRIPTION
Bumps the Rust crate `flate2` from 1.1.9 to 1.1.10 in `native/`.

This is a `Cargo.lock`-only change — `flate2` is a transitive dependency, so no `Cargo.toml` edit is needed.

## What changed upstream

Commits between `1.1.9` and `1.1.10`:

- `feat: reuse zlib's decoder buffer` ([#532](https://github.com/rust-lang/flate2-rs/pull/532)) — decoder buffer reuse, an allocation optimisation
- `feat: add reset method for read::GzDecoder and buffered::GzDecoder` ([#534](https://github.com/rust-lang/flate2-rs/pull/534)) — new API, additive
- `Drop cloudflare-zlib feature support` ([#539](https://github.com/rust-lang/flate2-rs/pull/539))
- `Add a wrapper for the Crc struct` — documentation/API-consistency fix

## Note on the backend

This bump also drops two crates from the lock file:

```
Removing adler2 v2.0.1
Removing miniz_oxide v0.8.9
Updating flate2 v1.1.9 -> v1.1.10
```

`zlib-rs` v0.6.7 was already in the lock file and remains the backend in use, so the `miniz_oxide`/`adler2` removal is dead weight being dropped rather than a switch of active backend. Because this crate produces DEFLATE-compressed output, the test suite was run with the NIF rebuilt from source to confirm output is still valid.

## Security review

Clean. No new dependencies added, two removed. No network or filesystem access introduced. The `cloudflare-zlib` feature that was dropped is not used here.

## Risk

**Low.** Additive API plus an allocation optimisation, with a net reduction in the dependency tree.

> [!NOTE]
> This library ships precompiled NIFs via `rustler_precompiled`. A `Cargo.lock` change does not invalidate the existing `checksum-*.exs` entries; consumers pick up the new Rust dependencies when the next release rebuilds the precompiled artifacts.
