### PR TITLE
chore(deps): bump rust indexmap from 2.14.0 to 2.14.1

### DIFF
--- a/native/xlsx_writer/Cargo.lock
+++ b/native/xlsx_writer/Cargo.lock
@@ -59,9 +59,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",


### PR DESCRIPTION
Bumps the Rust crate `indexmap` from 2.14.0 to 2.14.1 in `native/`.

This is a `Cargo.lock`-only change — `indexmap` is a transitive dependency, so no `Cargo.toml` edit is needed.

## Changelog

> ## 2.14.1 (2026-08-28)
>
> - Simplify comparisons where `Equivalent` isn't needed (`Q = K`).
> - Unify index assertions for bounds checks.
> - Fix (or `expect`) clippy lints.

Maintenance and code-quality only — no feature additions, no API changes, no breaking changes.

## Security review

Clean. No new dependencies, no network or filesystem access, no unsafe-code changes of note.

## Risk

**Very low.** Internal tidy-up in a patch release.

> [!NOTE]
> This library ships precompiled NIFs via `rustler_precompiled`. A `Cargo.lock` change does not invalidate the existing `checksum-*.exs` entries; consumers pick up the new Rust dependencies when the next release rebuilds the precompiled artifacts.
