### PR TITLE
ci: update actions to their current major versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Extract project version
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
             elixir: "1.20.2"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -50,7 +50,7 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - name: Cache hex deps
         id: mix-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             deps


### PR DESCRIPTION
Brings every third-party GitHub Action in this repository to its current major version. One PR per repository; this is part of an org-wide sweep.

## Versions

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 / v5 / v6 | **v7** |
| `actions/cache` | v4 / v5 | **v6** |
| `actions/setup-node` | v4 | **v7** |
| `actions/setup-java` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `gradle/actions/setup-gradle` | v4 | **v5** — deliberately not v6, see below |

Already current and untouched: `docker/login-action@v4`, `docker/build-push-action@v7`, `docker/setup-buildx-action@v4`, `docker/setup-qemu-action@v4`, `aws-actions/configure-aws-credentials@v6`, `aws-actions/amazon-ecr-login@v2`, `erlef/setup-beam@v1`, `softprops/action-gh-release@v3`, `ruby/setup-ruby@v1`, `philss/rustler-precompiled-action@v1.1.5`, `dtolnay/rust-toolchain@stable`. Internal `floatpays/*` references track `@main` and are not versioned.

## Compatibility checked, not assumed

**Node 24 runtime.** `actions/cache@v5+`, `actions/setup-node@v5+` and `actions/upload-artifact@v5+` moved to the Node 24 runtime and require **Actions Runner >= 2.327.1**. GitHub-hosted runners are fine. `gateway` is the only repository on self-hosted runners (per `github_actions_runner_repositories` in `infra-development/github-actions-runner.tf`); its CodeBuild runner reports **2.337.0**, so it clears the requirement.

**`gradle/actions` stops at v5.** v6 extracted the caching into a separate, **no longer open-source** `gradle-actions-caching` library and removed configuration-cache support. v5's only breaking change is the Node 24 move. v5 is therefore the latest version that keeps the current caching behaviour.

## In this repository

`.github/workflows/release.yml` and `.github/workflows/tests.yml` — `actions/checkout` → `@v7` and `actions/cache@v5` → `@v6`. `dtolnay/rust-toolchain@stable`, `philss/rustler-precompiled-action@v1.1.5` and `softprops/action-gh-release@v3` are already current.

The release workflow runs a matrix across `matrix.job.os`, all GitHub-hosted, so the Node 24 runner floor is satisfied.